### PR TITLE
Fix default volume mount permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN set -xo pipefail \
             echo 'app_update ${CSGO_APP_ID}'; \
             echo 'quit'; \
         } > ${STEAM_DIR}/autoupdate_script.txt \
+      && mkdir ${CSGO_DIR} \
       && chown -R steam:steam ${STEAM_DIR} \
       && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #20 

If `/home/steam/csgo` doesn't already exist when a volume is mounted, the mounted volume will default to root ownership and then the `steamcmd` script won't be able to write/install to it since it runs as the `steam` user.

This fix creates the directory right before the `steam` user is made owner.