### PR TITLE
Patch srcds_run to fix autoupdate

### DIFF
--- a/containerfs/start.sh
+++ b/containerfs/start.sh
@@ -95,5 +95,13 @@ if [[ -n $WORKSHOP_START_MAP ]]; then
   SRCDS_ARGUMENTS+=("+workshop_start_map $WORKSHOP_START_MAP")
 fi
 
+SRCDS_RUN="$CSGO_DIR/srcds_run"
+
+# Patch srcds_run to fix autoupdates
+if grep -q 'steam.sh' "$SRCDS_RUN"; then
+  sed -i 's/steam.sh/steamcmd.sh/' "$SRCDS_RUN"
+  echo "Applied patch to srcds_run to fix autoupdates"
+fi
+
 # Start the server
-exec "$BASH" "$CSGO_DIR/srcds_run" "${SRCDS_ARGUMENTS[@]}"
+exec "$BASH" "$SRCDS_RUN" "${SRCDS_ARGUMENTS[@]}"


### PR DESCRIPTION
The official `srcds_run` script has a bug in it on line 301. It refers to `steam.sh` instead of `steamcmd.sh`, resulting in file not found errors when attempting to use steamcmd to apply updates to CSGO automatically.

This will patch `srcds_run` at runtime.

Fixes #26 