### PR TITLE
Fix replacing env vars in config files at startup

### DIFF
--- a/containerfs/start.sh
+++ b/containerfs/start.sh
@@ -70,9 +70,9 @@ exec banned_ip.cfg
 AUTOEXECCFG
 
 else
-sed -i 's/^hostname.*/hostname "$SERVER_HOSTNAME"/' $CSGO_DIR/csgo/cfg/autoexec.cfg
-sed -i 's/^rcon_password.*/rcon_password "$RCON_PASSWORD"/' $CSGO_DIR/csgo/cfg/autoexec.cfg
-sed -i 's/^sv_password.*/sv_password "$SERVER_PASSWORD"/' $CSGO_DIR/csgo/cfg/autoexec.cfg
+sed -i "s/^hostname.*/hostname \"$SERVER_HOSTNAME\"/" $CSGO_DIR/csgo/cfg/autoexec.cfg
+sed -i "s/^rcon_password.*/rcon_password \"$RCON_PASSWORD\"/" $CSGO_DIR/csgo/cfg/autoexec.cfg
+sed -i "s/^sv_password.*/sv_password \"$SERVER_PASSWORD\"/" $CSGO_DIR/csgo/cfg/autoexec.cfg
 
 fi
 
@@ -99,7 +99,7 @@ sv_minupdaterate $TICKRATE
 SERVERCFG
 
 else
-sed -i 's/^tv_enable.*/tv_enable $TV_ENABLE/' $CSGO_DIR/csgo/cfg/server.cfg
+sed -i "s/^tv_enable.*/tv_enable $TV_ENABLE/" $CSGO_DIR/csgo/cfg/server.cfg
 
 fi
 


### PR DESCRIPTION
Previously the logic that updates autoexec.cfg and server.cfg on
startup used single quotes in the call to sed. Double quotes are
required to actually replace the environment variable name with
its content, though.

@kaimallea Not sure why I didn't see the issue earlier, probably because it was masked by 'sed -i -n' actually emptying the whole file anyway. Sorry about this.
To be honest I am wondering how this config file update logic worked for anyone before. Maybe no one else ran into these issues because it was introduced only recently?